### PR TITLE
Use the parent PK type in the jointure table PK.

### DIFF
--- a/src/EqualNestBehavior.php
+++ b/src/EqualNestBehavior.php
@@ -42,7 +42,7 @@ class EqualNestBehavior extends Behavior
             $this->getTable()->addColumn(array(
                 'name'          => $this->getReferenceColumn1Name(),
                 'primaryKey'    => 'true',
-                'type'          => 'INTEGER'
+                'type'          => $parentTablePrimaryKey[0]->getType(),
             ));
 
             $fk = new ForeignKey();
@@ -58,7 +58,7 @@ class EqualNestBehavior extends Behavior
             $this->getTable()->addColumn(array(
                 'name'          => $this->getReferenceColumn2Name(),
                 'primaryKey'    => 'true',
-                'type'          => 'INTEGER',
+                'type'          => $parentTablePrimaryKey[0]->getType(),
             ));
 
             $fk = new ForeignKey();

--- a/tests/EqualNestBehaviorTest.php
+++ b/tests/EqualNestBehaviorTest.php
@@ -466,4 +466,30 @@ XML;
 XML;
         $this->getBuilder($schema)->build();
     }
+
+    public function testPkMatchParentPkType(){
+        $schema = <<<XML
+<database name="equal_nest_behavior_4">
+    <table name="person_4">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="BIGINT" />
+        <column name="name" type="VARCHAR" required="true" />
+    </table>
+
+    <table name="friend_4">
+        <behavior name="equal_nest">
+            <parameter name="parent_table" value="person_4" />
+        </behavior>
+    </table>
+</database>
+XML;
+        $build = $this->getBuilder($schema)->build();
+        $parentTable = new Person4TableMap();
+        $table = new Friend4TableMap();
+
+        list($parentKey) = $parentTable->getPrimaryKeyColumns();
+        $pks = $table->getPrimaryKeyColumns();
+        foreach($pks as $pk) {
+            $this->assertTrue($pk->getType() === $parentKey->getType());
+        }
+    }
 }


### PR DESCRIPTION
EqualNestBehavior only supports primary keys of type integer.

This patch creates the schema using the type of the parent primary key.
